### PR TITLE
Allow ${INSTALLDIR}_build_target to be customized

### DIFF
--- a/build-canadian.sh
+++ b/build-canadian.sh
@@ -6,12 +6,16 @@ if [[ "$HOSTMACH" == "$BUILDMACH" ]]; then
 	exit $?
 fi
 
+if [ -z $INSTALLDIR_BUILD_TARGET ]; then
+	INSTALLDIR_BUILD_TARGET=${INSTALLDIR}_build_target
+fi
+
 if [ -z $NPROC ]; then
 	export NCPU=`nproc`
 fi
 
 [ -d $INSTALLDIR ] && rm -rf $INSTALLDIR
-[ -d ${INSTALLDIR}_build_target ] && rm -rf ${INSTALLDIR}_build_target
+[ -d ${INSTALLDIR_BUILD_TARGET} ] && rm -rf ${INSTALLDIR_BUILD_TARGET}
 
 HOSTORIG=$HOSTMACH
 PREFIXORIG=$PROGRAM_PREFIX
@@ -72,9 +76,9 @@ if [ $? -ne 0 ]; then
 fi
 export PROGRAM_PREFIX=$PREFIXORIG
 
-mv ${INSTALLDIR} ${INSTALLDIR}_build_target
+mv ${INSTALLDIR} ${INSTALLDIR_BUILD_TARGET}
 
-export PATH=${INSTALLDIR}_build_target/bin:$PATH
+export PATH=${INSTALLDIR_BUILD_TARGET}/bin:$PATH
 
 # Build the cross compiler for the target using the host to build
 export HOSTMACH=$HOSTORIG


### PR DESCRIPTION
The motivation for this is to make it easier to include this in the [Homebrew](http://brew.sh) package manager for OS X.

Homebrew builds packages using OS X's sandbox, configured to only allow writes to the target directory (e.g. `INSTALLDIR`) and to the temporary build directory. The step in `build-canadian.sh` which moves the cross-compiler from `${INSTALLDIR}` to `${INSTALLDIR}_build_target` results in the cross-compiler being moved outside one of the sandbox-writable areas, so the install would fail. This patch lets the build_target directory be configured via the `INSTALLDIR_BUILD_TARGET` environment variable, which defaults to the same path as it does currently.

I have a [package](https://github.com/mistydemeo/homebrew-formulae/blob/master/saturn-sdk-gcc-sh2.rb) for saturn-sdk-gcc-sh2 already, which works if the sandbox is disabled; I'm planning to move it into one of the official Homebrew repositories if this patch is accepted. Thanks!
