### PR TITLE
Allow skipping downloads using $SKIP_DOWNLOAD

### DIFF
--- a/README
+++ b/README
@@ -24,3 +24,6 @@ BUILDMACH is the development machine the compiler will run on.
 The BUILDMACH is the system architecture the compiler will run on, while the
 TARGETMARCH is the architecture the program or library created will run on.
 
+SKIP_DOWNLOAD can be set to any string to skip the call to `download.sh`, for
+example if the dependency tarballs have already been downloaded using something
+else.

--- a/build-canadian.sh
+++ b/build-canadian.sh
@@ -20,11 +20,13 @@ fi
 HOSTORIG=$HOSTMACH
 PREFIXORIG=$PROGRAM_PREFIX
 
-./download.sh
+if [ ! -z $SKIP_DOWNLOAD ]; then
+	./download.sh
 
-if [ $? -ne 0 ]; then
-	echo "Failed to retrieve the files necessary for building GCC"
-	exit 1
+	if [ $? -ne 0 ]; then
+		echo "Failed to retrieve the files necessary for building GCC"
+		exit 1
+	fi
 fi
 
 ./extract-source.sh

--- a/build.sh
+++ b/build.sh
@@ -12,11 +12,13 @@ fi
 
 [ -d $INSTALLDIR ] && rm -rf $INSTALLDIR
 
-./download.sh
+if [ ! -z $SKIP_DOWNLOAD]; then
+	./download.sh
 
-if [ $? -ne 0 ]; then
-	echo "Failed to retrieve the files necessary for building GCC"
-	exit 1
+	if [ $? -ne 0 ]; then
+		echo "Failed to retrieve the files necessary for building GCC"
+		exit 1
+	fi
 fi
 
 ./extract-source.sh


### PR DESCRIPTION
This is another thing that's useful for me in the Homebrew packaging. There, I've commented out the call to `./download.sh`, since Homebrew downloads the tarballs separately using its own mechanism; that lets me cache the downloads persistently to a location that isn't writeable during the build itself. It'd be helpful for me to configure that using an environment variable instead.
