### PR TITLE
Build scripts: check $NCPU, not $NPROC

### DIFF
--- a/build-canadian.sh
+++ b/build-canadian.sh
@@ -11,7 +11,16 @@ if [ -z $INSTALLDIR_BUILD_TARGET ]; then
 fi
 
 if [ -z $NCPU ]; then
-	export NCPU=`nproc`
+	# Mac OS X
+	if $(command -v sysctl >/dev/null 2>&1); then
+		export NCPU=`sysctl -n hw.ncpu`
+	# coreutils
+	elif $(command -v nproc >/dev/null 2>&1); then
+		export NCPU=`nproc`
+	# fallback to non-parallel build if we still have no idea
+	else
+		export NCPU=1
+	fi
 fi
 
 [ -d $INSTALLDIR ] && rm -rf $INSTALLDIR

--- a/build-canadian.sh
+++ b/build-canadian.sh
@@ -10,7 +10,7 @@ if [ -z $INSTALLDIR_BUILD_TARGET ]; then
 	INSTALLDIR_BUILD_TARGET=${INSTALLDIR}_build_target
 fi
 
-if [ -z $NPROC ]; then
+if [ -z $NCPU ]; then
 	export NCPU=`nproc`
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ if [[ "$HOSTMACH" != "$BUILDMACH" ]]; then
 	exit $?
 fi
 
-if [ -z $NPROC ]; then
+if [ -z $NCPU ]; then
 	export NCPU=`nproc`
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,16 @@ if [[ "$HOSTMACH" != "$BUILDMACH" ]]; then
 fi
 
 if [ -z $NCPU ]; then
-	export NCPU=`nproc`
+	# Mac OS X
+	if $(command -v sysctl >/dev/null 2>&1); then
+		export NCPU=`sysctl -n hw.ncpu`
+	# coreutils
+	elif $(command -v nproc >/dev/null 2>&1); then
+		export NCPU=`nproc`
+	# fallback to non-parallel build if we still have no idea
+	else
+		export NCPU=1
+	fi
 fi
 
 [ -d $INSTALLDIR ] && rm -rf $INSTALLDIR


### PR DESCRIPTION
It looks like this might have been a typo in 09ebde7d, since the original code always read/assigned to `$NCPU` and not `$NPROC`.
