### PR TITLE
Add space between $SKIP_DOWNLOAD and "]"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -137,7 +137,7 @@ fi
 
 [ -d $INSTALLDIR ] && rm -rf $INSTALLDIR
 
-if [ -z $SKIP_DOWNLOAD]; then
+if [ -z $SKIP_DOWNLOAD ]; then
 	./download.sh
 
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
Fixes error:

% ./build-elf.sh
./build.sh: line 140: [: missing `]'